### PR TITLE
Resolve system temp dir to a real dir

### DIFF
--- a/src/cli/Kahlan.php
+++ b/src/cli/Kahlan.php
@@ -313,7 +313,7 @@ EOD;
                 'include'    => $this->args()->get('include'),
                 'exclude'    => array_merge($this->args()->get('exclude'), ['kahlan\\']),
                 'persistent' => $this->args()->get('persistent'),
-                'cachePath'  => rtrim(sys_get_temp_dir(), DS) . DS . 'kahlan'
+                'cachePath'  => rtrim(realpath(sys_get_temp_dir()), DS) . DS . 'kahlan'
             ]);
         });
     }


### PR DESCRIPTION
On my Mac install the sys_get_temp_dir() call returns a symlink. This prevents coverage from working as the paths provided by Xdebug are all resolved paths, so their paths don't match up with the cachePath generated here.