### PR TITLE
Only add a default when the interface specifies one

### DIFF
--- a/spec/fixture/plugin/stub/DozInterface.php
+++ b/spec/fixture/plugin/stub/DozInterface.php
@@ -4,5 +4,5 @@ namespace kahlan\spec\fixture\plugin\stub;
 interface DozInterface
 {
     public function foo($a);
-    public function bar($b);
+    public function bar($b = null);
 }

--- a/spec/suite/plugin/StubSpec.php
+++ b/spec/suite/plugin/StubSpec.php
@@ -757,7 +757,7 @@ namespace kahlan\\spec\\plugin\\stub;
 
 class Stub extends \\kahlan\\spec\\fixture\\plugin\\stub\\Doz {
 
-    public function foo(\$var = NULL) {}
+    public function foo(\$var) {}
     public function bar(\$var1 = NULL, array \$var2 = array()) {}
 
 }
@@ -806,7 +806,7 @@ namespace kahlan\\spec\\plugin\\stub;
 
 class Stub implements \\kahlan\\spec\\fixture\\plugin\\stub\\DozInterface {
 
-    public function foo(\$a = NULL) {}
+    public function foo(\$a) {}
     public function bar(\$b = NULL) {}
 
 }
@@ -827,7 +827,7 @@ namespace kahlan\\spec\\plugin\\stub;
 
 class Stub extends \\kahlan\\spec\\fixture\\plugin\\stub\\Doz implements \\kahlan\\spec\\fixture\\plugin\\stub\\DozInterface {
 
-    public function foo(\$var = NULL) {}
+    public function foo(\$var) {}
     public function bar(\$var1 = NULL, array \$var2 = array()) {}
 
 }

--- a/src/plugin/Stub.php
+++ b/src/plugin/Stub.php
@@ -475,10 +475,8 @@ EOT;
             $default = '';
             if ($parameter->isDefaultValueAvailable()) {
                 $default = var_export($parameter->getDefaultValue(), true);
-            } else {
-                $default = 'NULL';
+                $default = ' = ' . preg_replace('/\s+/', '', $default);
             }
-            $default = ' = ' . preg_replace('/\s+/', '', $default);
 
             $params[] = "{$typehint}{$reference}\${$name}{$default}";
         }


### PR DESCRIPTION
Interfaces and classes with typehints will break if you add a default value while there is none in the parent class/interface.