### PR TITLE
Return absolute namespace for typehint

### DIFF
--- a/spec/suite/analysis/InspectorSpec.php
+++ b/spec/suite/analysis/InspectorSpec.php
@@ -78,7 +78,7 @@ describe("Inspector", function() {
             $inspector = Inspector::parameters($this->class, 'exceptionTypeHint');
             $typehint = Inspector::typehint(current($inspector));
             expect($typehint)->toBeA('string');
-            expect(trim($typehint))->toBe('Exception');
+            expect(trim($typehint))->toBe('\\Exception');
 
             $inspector = Inspector::parameters($this->class, 'arrayTypeHint');
             $typehint = Inspector::typehint(current($inspector));

--- a/src/analysis/Inspector.php
+++ b/src/analysis/Inspector.php
@@ -71,7 +71,7 @@ class Inspector
         if ($parameter->isArray()) {
             $typehint = 'array ';
         } elseif ($parameter->getClass()) {
-            $typehint = $parameter->getClass()->getName() . ' ';
+            $typehint = '\\' . $parameter->getClass()->getName() . ' ';
         } elseif (preg_match('/.*?\[ \<[^\>]+\> (\S+ )(.*?)\$/', (string) $parameter, $match)) {
             $typehint = $match[1];
         }


### PR DESCRIPTION
These global namespaces make sure that typehints are actually correct for stubbed classes. Because the stubbed class is namespaced, the typehint would otherwise break as PHP assumes it is relative to the stub namespace.

It might be a good idea to actually create a test-case with typehints to namespaced classes.