### PR TITLE
Improvements in Stub.

### DIFF
--- a/src/plugin/Stub.php
+++ b/src/plugin/Stub.php
@@ -429,6 +429,7 @@ EOT;
         $reflection = Inspector::inspect($class);
         $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
         foreach ($methods as $method) {
+            if ($method->getModifiers() & ReflectionMethod::IS_FINAL) continue;
             $result[$method->getName()] = static::_generateMethod($method, true);
         }
         return $result;
@@ -523,6 +524,8 @@ EOT;
             if ($parameter->isDefaultValueAvailable()) {
                 $default = var_export($parameter->getDefaultValue(), true);
                 $default = ' = ' . preg_replace('/\s+/', '', $default);
+            } else if ($parameter->isOptional()) {
+                $default = ' = null';
             }
 
             $params[] = "{$typehint}{$reference}\${$name}{$default}";


### PR DESCRIPTION
Patch related to #33.
Don't allow Stub to patch a final methods.
Provide correct signature for a "$param = null" params.