### PR TITLE
Add missing closing backticks for code block

### DIFF
--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -225,6 +225,7 @@ it("passes if $actual matches the $expected closure logic", function() {
     });
 
 });
+```
 
 ### <a name="method"></a>Method invocation matchers
 


### PR DESCRIPTION
Hi folks,

Here's a small typo fix. The rendered HTML is currently messed up because of the missing backticks.

As a side note, I've just started to read the docs for Kahlan and I'm pretty excited, this looks very promising.

Beau boulot :+1: