### PR TITLE
phpDoc of toThrow() Matcher method

### DIFF
--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -20,7 +20,7 @@ use kahlan\analysis\Inspector;
  * @method Matcher toBeCloseTo(float $expected, int $precision) passes if actual is close to expected in some precision
  * @method Matcher toBeGreaterThan(mixed $expected) passes if actual if greater than expected
  * @method Matcher toBeLessThan(mixed $expected) passes if actual is less than expected
- * @method Matcher toThrow(mixed $expected) passes if actual throws the expeted exception
+ * @method Matcher toThrow(mixed $expected = null) passes if actual throws the expected exception
  * @method Matcher toMatch(string $expected) passes if actual matches the expected regexp
  * @method Matcher toEcho(string $expected) passes if actual echoes the expected string
  * @method Matcher toMatchEcho(string $expected) passes if actual echoes matches the expected string


### PR DESCRIPTION
Accordingly to [documentation](http://kahlan.readthedocs.org/en/latest/matchers/) it is allowed to use `toThrow()` matcher without any arguments and it works as expected.
However, some IDEs may perform static analysis and say there is an error as far as phpDoc `@method` tag does not allow any default parameters and some parameter must be passed explicitly.

Example for phpStorm 8.0.3:
![fails](https://habrastorage.org/files/9bf/b2d/bed/9bfb2dbed92243d2b152d8bc37455918.png)
![okt](https://habrastorage.org/files/ce6/5d7/e75/ce65d7e759a54509af68e4832c0881a6.png)