### PR TITLE
update git clone command to no need to use public/private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Kahlan uses the [ferver](https://github.com/jonathanong/ferver) versioning so a 
 ### via Git clone
 
 ```
-git clone git@github.com:crysalead/kahlan.git
+git clone git://github.com/crysalead/kahlan.git
 cd kahlan
 composer install
 bin/kahlan              # to run specs or,


### PR DESCRIPTION
now it no need to use public/private key to just clone