### PR TITLE
Added ability to disable Kahlan functions by environment variable.

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -7,7 +7,7 @@ if (!defined('DS')) {
 }
 error_reporting(E_ALL);
 
-if (!defined('KAHLAN_DISABLE_FUNCTIONS') || !KAHLAN_DISABLE_FUNCTIONS) {
+if (!defined('KAHLAN_DISABLE_FUNCTIONS') || !KAHLAN_DISABLE_FUNCTIONS || !getenv('KAHLAN_DISABLE_FUNCTIONS')) {
 
     function before($closure) {
         return Suite::current()->before($closure);


### PR DESCRIPTION
Hello.

We are using Behat and PhpSpec (our old specs) among with Kahlan. They do not work with Kahlan functions enabled. We want to disable them by shell variable. This will allow us.