### PR TITLE
Implements RSpec `let` through `given()` function.

### DIFF
--- a/spec/suite/GivenSpec.php
+++ b/spec/suite/GivenSpec.php
@@ -1,0 +1,142 @@
+<?php
+namespace kahlan\spec\suite;
+
+use Exception;
+use kahlan\Scope;
+use kahlan\Given;
+
+describe("Given", function() {
+
+    given('scope', function() { return 'root'; });
+
+    context("using the global `given()` function", function() {
+
+        it("gets a lazy loadable variable", function() {
+
+            given('firstname', function() { return 'Willy'; });
+            expect($this->firstname)->toBe('Willy');
+
+        });
+
+        it("lazy loads variables in cascades", function() {
+
+            given('firstname', function() { return 'Johnny'; });
+            given('fullname', function() {
+                return "{$this->firstname} {$this->lastname}";
+            });
+            given('lastname', function() { return 'Boy'; });
+            expect($this->fullname)->toBe('Johnny Boy');
+
+        });
+
+        it("allows to reference a lazy loadable variable which get overrided", function() {
+
+            given('variable', function() { return []; });
+            given('variable', function() {
+                $this->variable[] = 1;
+                return $this->variable;
+            });
+            given('variable', function() {
+                $this->variable[] = 2;
+                return $this->variable;
+            });
+            expect($this->variable)->toBe([1, 2]);
+
+        });
+
+        context("with a nested scope", function() {
+
+            $count = 0;
+            given('count', function() use (&$count) {
+                return ++$count;
+            });
+
+            it("caches lazy loaded variables", function() {
+
+                expect($this->count)->toBe(1);
+                expect($this->count)->toBe(1);
+                expect($this->count)->toBe(1);
+
+            });
+
+            it("doesn't cache across specifications",  function() {
+
+                expect($this->count)->toBe(2);
+                expect($this->count)->toBe(2);
+                expect($this->count)->toBe(2);
+
+            });
+        });
+
+        context('using a nested context', function() {
+
+            it("gets a lazy loadable variable defined in a parent context", function() {
+
+                expect($this->scope)->toBe('root');
+
+            });
+
+            it("can override a lazy loadable variable defined in a parent context", function() {
+
+                given('scope', function() { return 'nested'; });
+                expect($this->scope)->toBe('nested');
+
+            });
+
+        });
+
+        context("using lazy loadable variables through `beforeEach()`", function() {
+
+            beforeEach(function() {
+                $this->value = $this->state;
+            });
+
+            given('state',  function() { return 'some_state'; });
+
+            it("makes lazy loadable variables loaded", function() {
+
+                expect($this->value)->toBe('some_state');
+
+            });
+
+        });
+
+        it("throw an exception when the second parameter is not a closure", function() {
+
+            $closure = function() {
+                given('some_name',  'some value');
+            };
+            expect($closure)->toThrow(new Exception("A closure is required by `Given` constructor."));
+
+        });
+
+        it("throw an exception for reserved keywords", function() {
+
+            foreach (Scope::$blacklist as $keyword => $bool) {
+                $closure = function() use ($keyword) {
+                    given($keyword,  function() { return 'some value'; });
+                };
+                expect($closure)->toThrow(new Exception("Sorry `{$keyword}` is a reserved keyword, it can't be used as a scope variable."));
+            }
+
+        });
+
+    });
+
+    describe("->__get()", function() {
+
+        it("throw an new exception when trying to access an undefined variable through a given definition", function() {
+
+            $closure = function() {
+                $given = new Given(function() {
+                    return $this->undefinedVariable;
+                });
+                $given();
+            };
+            expect($closure)->toThrow(new Exception("Undefined variable `undefinedVariable`."));
+
+        });
+
+    });
+
+});

--- a/src/Given.php
+++ b/src/Given.php
@@ -1,0 +1,83 @@
+<?php
+namespace kahlan;
+
+use Exception;
+
+class Given
+{
+    /**
+     * The parent scope.
+     *
+     * @var object
+     */
+    protected $_parent = null;
+
+    /**
+     * The scope's data.
+     *
+     * @var array
+     */
+    protected $_data = [];
+
+    /**
+     * The given value or a factory closure.
+     *
+     * @var mixed
+     */
+    protected $_closure = null;
+
+    /**
+     * The Constructor.
+     *
+     * @param array $closure A closure.
+     */
+    public function __construct($closure)
+    {
+        $this->_closure = $closure;
+        if (!is_callable($this->_closure)) {
+            throw new Exception("A closure is required by `Given` constructor.");
+        }
+        $this->_closure = $this->_closure->bindTo($this);
+    }
+
+    /**
+     * Returns the given data
+     *
+     * @return mixed
+     */
+    public function __invoke($parent = null)
+    {
+        $this->_parent = $parent;
+        $closure = $this->_closure;
+        return $closure();
+    }
+
+    /**
+     * Getter.
+     *
+     * @param  string $key The name of the variable.
+     * @return mixed  The value of the variable.
+     */
+    public function &__get($key)
+    {
+        if (array_key_exists($key, $this->_data)) {
+            return $this->_data[$key];
+        }
+        if ($this->_parent !== null) {
+            return $this->_parent->__get($key);
+        }
+        throw new Exception("Undefined variable `{$key}`.");
+    }
+
+    /**
+     * Setter.
+     *
+     * @param  string $key   The name of the variable.
+     * @param  mixed  $value The value of the variable.
+     * @return mixed  The value of the variable.
+     */
+    public function __set($key, $value)
+    {
+        return $this->_data[$key] = $value;
+    }
+}

--- a/src/init.php
+++ b/src/init.php
@@ -48,6 +48,10 @@ if ($defineFuctions) {
         return Suite::current()->context($message, $closure, $timeout, $scope);
     }
 
+    function given($name, $value) {
+        return Suite::current()->given($name, $value);
+    }
+
     function it($message, $closure, $timeout = null, $scope = 'normal') {
         return Suite::current()->it($message, $closure, $timeout, $scope);
     }


### PR DESCRIPTION
This PR is an attempt to implements RSpec's `let` feature for Kahlan.

`given()`  takes two parameters:
* a name
* a function to be executed lazily.

The function will be evaluated once and cached on a per context basis.

Example:
```php
describe("given()", function() {
    given('firstname', function() { return 'Johnny'; });
    given('fullname', function() {
        return "{$this->firstname} {$this->lastname}";
    });
    given('lastname', function() { return 'Boy'; });

    it("lazy loads variables in cascades", function() {      
        expect($this->fullname)->toBe('Johnny Boy');
    });
});


```

PS: since `let` is a reserved keyword in Javascript and I would like to provide some comptatibles matchers through [jasmine](https://github.com/crysalead-js/jasmine-kahlan) and [mocha](https://github.com/crysalead-js/chai-kahlan), so `given()` has been using here instead of `let`.