### PR TITLE
Fixed backtrace to pass when source is not in kahlan folder.

### DIFF
--- a/spec/Suite/Analysis/DebuggerSpec.php
+++ b/spec/Suite/Analysis/DebuggerSpec.php
@@ -56,7 +56,7 @@ describe("Debugger", function() {
             expect($backtrace)->toBeA('string');
 
             $trace = current(explode("\n", $backtrace));
-            expect($trace)->toMatch('~kahlan[/|\\\]src[/|\\\]Specification.php~');
+            expect($trace)->toMatch('~src[/|\\\]Specification.php~');
 
         });
 


### PR DESCRIPTION
In example we have a source located at: `/var/www/kahlan.source/`
And we checkout like this: `git clone git://github.com/crysalead/kahlan.git .`

And without this fix we always have a one spec fail.
No need to check a kahlan folder it matcher.