### PR TITLE
fixes #121. adding / in front of non-builtin return types

### DIFF
--- a/spec/Fixture/Plugin/Stub/ReturnTypesInterface.php
+++ b/spec/Fixture/Plugin/Stub/ReturnTypesInterface.php
@@ -4,4 +4,5 @@ namespace Kahlan\Spec\Fixture\Plugin\Stub;
 interface ReturnTypesInterface
 {
     public function foo(array $a) : bool;
+    public function bar() : \Kahlan\Spec\Fixture\Reporter\Coverage\ImplementsCoverageInterface;
 }

--- a/spec/Suite/Plugin/StubSpec.php
+++ b/spec/Suite/Plugin/StubSpec.php
@@ -868,6 +868,7 @@ namespace Kahlan\\Spec\\Plugin\\Stub;
 class Stub implements \\Kahlan\\Spec\\Fixture\\Plugin\\Stub\\ReturnTypesInterface {
 
     public function foo(array \$a) : bool {}
+    public function bar() : \\Kahlan\\Spec\\Fixture\\Reporter\\Coverage\\ImplementsCoverageInterface {}
 
 }
 ?>

--- a/src/Plugin/Stub.php
+++ b/src/Plugin/Stub.php
@@ -504,6 +504,10 @@ EOT;
         $parameters = static::_generateSignature($method);
         if (PHP_MAJOR_VERSION >= 7) {
             $type = $method->getReturnType();
+            if ($type && !$type->isBuiltin()) {
+                $type = '\\' . $type;
+            }
+
             $type = $type ? ": {$type} " : '';
         } else {
             $type = '';


### PR DESCRIPTION
fixes #121 Stub::_generateMethod() fails to generate return types of non-builtins correctly

adding `\` in front of non-builtin types