### PR TITLE
Updates PHP DocBlocks for better compatibility with IDEs

### DIFF
--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -2,12 +2,9 @@
 namespace Kahlan\Cli;
 
 use Kahlan\Dir\Dir;
-use Kahlan\Cli;
 use Kahlan\Jit\Interceptor;
-use Kahlan\Jit\Patchers;
 use Kahlan\Filter\Filter;
 use Kahlan\Filter\Behavior\Filterable;
-use Kahlan\Suite;
 use Kahlan\Matcher;
 use Kahlan\Jit\Patcher\Pointcut;
 use Kahlan\Jit\Patcher\Monkey;
@@ -15,8 +12,6 @@ use Kahlan\Jit\Patcher\Rebase;
 use Kahlan\Jit\Patcher\Quit;
 use Kahlan\Plugin\Quit as QuitStatement;
 use Kahlan\Reporters;
-use Kahlan\Reporter\Dot;
-use Kahlan\Reporter\Bar;
 use Kahlan\Reporter\Terminal;
 use Kahlan\Reporter\Coverage;
 use Kahlan\Reporter\Coverage\Driver\Phpdbg;

--- a/src/Given.php
+++ b/src/Given.php
@@ -30,6 +30,8 @@ class Given
      * The Constructor.
      *
      * @param array $closure A closure.
+     *
+     * @throws Exception
      */
     public function __construct($closure)
     {
@@ -56,7 +58,9 @@ class Given
      * Getter.
      *
      * @param  string $key The name of the variable.
-     * @return mixed  The value of the variable.
+     *
+     * @return mixed The value of the variable.
+     * @throws Exception
      */
     public function &__get($key)
     {

--- a/src/Matcher.php
+++ b/src/Matcher.php
@@ -64,7 +64,9 @@ class Matcher
      *
      * @param  string $name   The name of the matcher.
      * @param  string $target An optionnal target class name.
-     * @return array          The registered matchers or a fully-namespaced class name if $name is not null.
+     *
+     * @return array The registered matchers or a fully-namespaced class name if $name is not null.
+     * @throws Exception
      */
     public static function get($name = null, $target = '')
     {

--- a/src/Plugin/Call/Message.php
+++ b/src/Plugin/Call/Message.php
@@ -55,7 +55,7 @@ class Message
      * Sets params requirement.
      *
      * @param  mixed  ... <0,n> Parameter(s).
-     * @return object     $this.
+     * @return self     $this.
      */
     public function with()
     {

--- a/src/Plugin/Stub.php
+++ b/src/Plugin/Stub.php
@@ -40,14 +40,14 @@ class Stub
     /**
      * Stubbed methods.
      *
-     * @var array
+     * @var Method[]
      */
     protected $_stubs = [];
 
     /**
      * Stub index counter.
      *
-     * @var array
+     * @var int
      */
     protected static $_index = 0;
 
@@ -65,7 +65,7 @@ class Stub
      * Getd/Setd stubs for methods or get stubbed methods array.
      *
      * @param  array $name An array of method names.
-     * @return mixed       Return the array of stubbed methods.
+     * @return Method[]       Return the array of stubbed methods.
      */
     public function methods($name = [])
     {
@@ -91,7 +91,7 @@ class Stub
      * @param  string $name    Method name or array of stubs where key are method names and
      *                         values the stubs.
      * @param  string $closure The stub implementation.
-     * @return object          The subbed method instance.
+     * @return Method          The stubbed method instance.
      */
     public function method($name, $closure = null)
     {
@@ -124,11 +124,11 @@ class Stub
      * Stubs class methods.
      *
      * @param  object|string $reference An instance or a fully-namespaced class name.
-     * @return object                   The Stub instance.
+     * @return self                   The Stub instance.
      */
     public static function on($reference)
     {
-        $hash = Suite::hash($reference);;
+        $hash = Suite::hash($reference);
         if (isset(static::$_registered[$hash])) {
             return static::$_registered[$hash];
         }

--- a/src/Plugin/Stub/Method.php
+++ b/src/Plugin/Stub/Method.php
@@ -8,14 +8,14 @@ class Method extends \Kahlan\Plugin\Call\Message
     /**
      * Index value in the `Method::$_returns` array.
      *
-     * @var array
+     * @var int
      */
     protected $_index = 0;
 
     /**
      * Stub implementation.
      *
-     * @var Closure
+     * @var \Closure
      */
     protected $_closure = null;
 
@@ -49,7 +49,7 @@ class Method extends \Kahlan\Plugin\Call\Message
     /**
      * Runs the stub.
      *
-     * @param  string $self   The context form which the stub need to be executed.
+     * @param  string $self   The context from which the stub need to be executed.
      * @param  array  $params The call parameters array.
      * @return mixed          The returned stub result.
      */
@@ -72,7 +72,7 @@ class Method extends \Kahlan\Plugin\Call\Message
     /**
      * Sets the stub logic.
      *
-     * @param Closure $closure The logic.
+     * @param \Closure $closure The logic.
      */
     public function run($closure)
     {

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -3,13 +3,14 @@ namespace Kahlan;
 
 use Exception;
 use Kahlan\Analysis\Debugger;
+use Kahlan\Plugin\Call\Message;
 
 class Scope
 {
     /**
      * Instances stack.
      *
-     * @var array
+     * @var Scope[]
      */
     protected static $_instances = [];
 
@@ -83,7 +84,7 @@ class Scope
     /**
      * The parent instance.
      *
-     * @var object
+     * @var Scope
      */
     protected $_parent = null;
 
@@ -97,7 +98,7 @@ class Scope
     /**
      * The spec closure.
      *
-     * @var Closure
+     * @var \Closure
      */
     protected $_closure = null;
 
@@ -216,6 +217,11 @@ class Scope
         ];
         $config += $defaults;
         $this->_classes += $config['classes'];
+        /**
+         * @var Message $message
+         * @var Scope $parent
+         * @var integer $timeout
+         */
         extract($config);
 
         $this->_message   = $message;
@@ -291,7 +297,7 @@ class Scope
      * Sets a lazy loaded data.
      *
      * @param  string  $name    The lazy loaded variable name.
-     * @param  Closure $closure The lazily executed closure.
+     * @param  \Closure $closure The lazily executed closure.
      * @return object
      */
     public function given($name, $closure)
@@ -311,7 +317,7 @@ class Scope
     /**
      * Gets the parent instance.
      *
-     * @return array
+     * @return Scope
      */
     public function parent()
     {
@@ -427,9 +433,11 @@ class Scope
     /**
      * Binds the closure to the current context.
      *
-     * @param  Closure  $closure The variable to check
-     * @param  string   $name Name of the parent type (TODO: to use somewhere).
-     * @throws Throw an Exception if the passed parameter is not a closure
+     * @param  \Closure $closure The variable to check
+     * @param  string   $name    Name of the parent type (TODO: to use somewhere).
+     *
+     * @return \Closure
+     * @throws \Exception Throw an Exception if the passed parameter is not a closure
      */
     protected function _bind($closure, $name)
     {

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -15,13 +15,14 @@ class Specification extends Scope
 
     /**
      * List of expectations.
+     * @var Expectation[]
      */
     protected $_expectations = [];
 
     /**
      * Constructor.
      *
-     * @param array $config The Suite config array. Options are:
+     * @param array $config  The Suite config array. Options are:
      *                       -`'closure'` _Closure_ : the closure of the test.
      *                       -`'scope'`   _string_  : supported scope are `'normal'` & `'focus'`.
      *                       -`'matcher'` _object_  : the matcher instance.
@@ -31,14 +32,17 @@ class Specification extends Scope
         $defaults = [
             'closure' => null,
             'message' => 'passes',
-            'scope'   => 'normal'
+            'scope' => 'normal',
         ];
         $config += $defaults;
         $config['message'] = 'it ' . $config['message'];
         parent::__construct($config);
 
 
-
+        /**
+         * @var \Closure $closure
+         * @var string   $scope
+         */
         extract($config);
 
         $this->_closure = $this->_bind($closure, 'it');
@@ -50,24 +54,32 @@ class Specification extends Scope
     /**
      * The expect statement.
      *
-     * @param mixed $actual The expression to check
+     * @param Expectation $actual The expression to check
+     *
+     * @return Expectation[]
      */
     public function expect($actual, $timeout = -1)
     {
         $expectation = $this->_classes['expectation'];
+
         return $this->_expectations[] = new $expectation(compact('actual', 'timeout'));
     }
 
     /**
      * The waitsFor statement.
      *
-     * @param mixed $actual The expression to check
+     * @param Expectation $actual The expression to check
+     *
+     * @return mixed
      */
     public function waitsFor($actual, $timeout = 0)
     {
         $timeout = $timeout ?: $this->timeout();
-        $actual = $actual instanceof Closure ? $actual : function() {return $actual;};
+        $actual = $actual instanceof Closure ? $actual : function () {
+            return $actual;
+        };
         $spec = new static(['closure' => $actual]);
+
         return $this->expect($spec, $timeout);
     }
 
@@ -75,7 +87,6 @@ class Specification extends Scope
      * Processes a child specs.
      *
      * @see Kahlan\Suite::process()
-     * @param object A child spec.
      */
     public function process()
     {
@@ -100,7 +111,8 @@ class Specification extends Scope
             $this->_exception($exception, true);
             try {
                 $this->_specEnd();
-            } catch (Exception $exception) {}
+            } catch (Exception $exception) {
+            }
         }
 
         return $result;
@@ -124,6 +136,7 @@ class Specification extends Scope
     {
         if (!$this->_parent) {
             $this->emitReport('specEnd', $this->report());
+
             return;
         }
         $this->_parent->runCallbacks('afterEach');
@@ -191,6 +204,7 @@ class Specification extends Scope
                 $logs[] = $log;
             }
         }
+
         return $logs;
     }
 

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -1,8 +1,8 @@
 <?php
 namespace Kahlan;
 
-use Exception;
 use Closure;
+use Exception;
 use InvalidArgumentException;
 use Kahlan\Analysis\Debugger;
 
@@ -25,7 +25,7 @@ class Suite extends Scope
     /**
      * The childs array.
      *
-     * @var array
+     * @var Scope[]|Specification[]
      */
     protected $_childs = [];
 
@@ -42,10 +42,10 @@ class Suite extends Scope
      * @var array
      */
     protected $_callbacks = [
-        'before'     => [],
-        'after'      => [],
+        'before' => [],
+        'after' => [],
         'beforeEach' => [],
-        'afterEach'  => []
+        'afterEach' => [],
     ];
 
     /**
@@ -73,7 +73,7 @@ class Suite extends Scope
     /**
      * The Constructor.
      *
-     * @param array $config The Suite config array. Options are:
+     * @param array $config  The Suite config array. Options are:
      *                       -`'closure'` _Closure_: the closure of the test.
      *                       -`'name'`    _string_ : the type of the suite.
      *                       -`'scope'`   _string_ : supported scope are `'normal'` & `'focus'`.
@@ -82,12 +82,17 @@ class Suite extends Scope
     {
         $defaults = [
             'closure' => null,
-            'name'    => 'describe',
-            'scope'   => 'normal'
+            'name' => 'describe',
+            'scope' => 'normal',
         ];
         $config += $defaults;
         parent::__construct($config);
 
+        /**
+         * @var \Closure $closure
+         * @var string   $name
+         * @var string   $scope
+         */
         extract($config);
 
         if ($this->_root === $this) {
@@ -105,6 +110,7 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     *
      * @return $this
      */
     public function describe($message, $closure, $timeout = null, $scope = 'normal')
@@ -113,6 +119,7 @@ class Suite extends Scope
         $name = 'describe';
         $timeout = $timeout !== null ? $timeout : $this->timeout();
         $suite = new Suite(compact('message', 'closure', 'parent', 'name', 'timeout', 'scope'));
+
         return $this->_childs[] = $suite;
     }
 
@@ -121,6 +128,9 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     * @param null     $timeout
+     * @param string   $scope
+     *
      * @return $this
      */
     public function context($message, $closure, $timeout = null, $scope = 'normal')
@@ -129,6 +139,7 @@ class Suite extends Scope
         $name = 'context';
         $timeout = $timeout !== null ? $timeout : $this->timeout();
         $suite = new Suite(compact('message', 'closure', 'parent', 'name', 'timeout', 'scope'));
+
         return $this->_childs[] = $suite;
     }
 
@@ -138,6 +149,7 @@ class Suite extends Scope
      * @param  string|Closure $message Description message or a test closure.
      * @param  Closure        $closure A test case closure.
      * @param  string         $scope   The scope.
+     *
      * @return $this
      */
     public function it($message, $closure = null, $timeout = null, $scope = 'normal')
@@ -154,6 +166,7 @@ class Suite extends Scope
         $timeout = $timeout !== null ? $timeout : $this->timeout();
         $spec = new Specification(compact('message', 'closure', 'parent', 'root', 'timeout', 'scope'));
         $this->_childs[] = $spec;
+
         return $this;
     }
 
@@ -162,6 +175,7 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     *
      * @return $this
      */
     public function xdescribe($message, $closure)
@@ -173,6 +187,7 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     *
      * @return $this
      */
     public function xcontext($message, $closure)
@@ -184,6 +199,7 @@ class Suite extends Scope
      *
      * @param  string|Closure $message Description message or a test closure.
      * @param  Closure|null   $closure A test case closure or `null`.
+     *
      * @return $this
      */
     public function xit($message, $closure = null)
@@ -195,6 +211,7 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     *
      * @return $this
      */
     public function fdescribe($message, $closure, $timeout = null)
@@ -207,6 +224,7 @@ class Suite extends Scope
      *
      * @param  string  $message Description message.
      * @param  Closure $closure A test case closure.
+     *
      * @return $this
      */
     public function fcontext($message, $closure, $timeout = null)
@@ -219,6 +237,7 @@ class Suite extends Scope
      *
      * @param  string|Closure $message Description message or a test closure.
      * @param  Closure|null   $closure A test case closure or `null`.
+     *
      * @return $this
      */
     public function fit($message, $closure = null, $timeout = null)
@@ -230,12 +249,14 @@ class Suite extends Scope
      * Executed before tests.
      *
      * @param  Closure $closure A closure
+     *
      * @return $this
      */
     public function before($closure)
     {
         $this->_bind($closure, 'before');
         $this->_callbacks['before'][] = $closure;
+
         return $this;
     }
 
@@ -248,6 +269,7 @@ class Suite extends Scope
     {
         $this->_bind($closure, 'after');
         $this->_callbacks['after'][] = $closure;
+
         return $this;
     }
 
@@ -255,12 +277,14 @@ class Suite extends Scope
      * Executed before each tests.
      *
      * @param  Closure $closure A closure
+     *
      * @return $this
      */
     public function beforeEach($closure)
     {
         $this->_bind($closure, 'beforeEach');
         $this->_callbacks['beforeEach'][] = $closure;
+
         return $this;
     }
 
@@ -273,13 +297,14 @@ class Suite extends Scope
     {
         $this->_bind($closure, 'afterEach');
         $this->_callbacks['afterEach'][] = $closure;
+
         return $this;
     }
 
     /**
      * Suite run.
      *
-     * @return array Process options.
+     * @param array $options
      */
     protected function process($options = [])
     {
@@ -291,7 +316,7 @@ class Suite extends Scope
 
         try {
             $this->_suiteStart();
-            foreach($this->_childs as $child) {
+            foreach ($this->_childs as $child) {
                 if ($this->failfast()) {
                     break;
                 }
@@ -302,7 +327,8 @@ class Suite extends Scope
             $this->_exception($exception);
             try {
                 $this->_suiteEnd();
-            } catch (Exception $exception) {}
+            } catch (Exception $exception) {
+            }
         }
 
         $this->_errorHandler(false);
@@ -350,7 +376,7 @@ class Suite extends Scope
     {
         $instances = $recursive ? $this->_parents(true) : [$this];
         foreach ($instances as $instance) {
-            foreach($instance->_callbacks[$name] as $closure) {
+            foreach ($instance->_callbacks[$name] as $closure) {
                 $closure($this);
             }
         }
@@ -359,10 +385,11 @@ class Suite extends Scope
     /**
      * Overrides the default error handler
      *
-     * @param boolean $enable If `true` override the default error handler,
-     *                if `false` restore the default handler.
+     * @param boolean $enable  If `true` override the default error handler,
+     *                         if `false` restore the default handler.
      * @param array   $options An options array. Available options are:
-     *                - 'handler': An error handler closure.
+     *                         - 'handler': An error handler closure.
+     *
      */
     protected function _errorHandler($enable, $options = [])
     {
@@ -371,7 +398,7 @@ class Suite extends Scope
         if (!$enable) {
             return restore_error_handler();
         }
-        $handler = function($code, $message, $file, $line = 0, $args = []) {
+        $handler = function ($code, $message, $file, $line = 0, $args = []) {
             $trace = debug_backtrace();
             $trace = array_slice($trace, 1, count($trace));
             $message = "`" . Debugger::errorType($code) . "` {$message}";
@@ -387,14 +414,16 @@ class Suite extends Scope
      * Runs all specs.
      *
      * @param  array $options Run options.
-     * @return array The result array.
+     *
+     * @return boolean The result array.
+     * @throws Exception
      */
     public function run($options = [])
     {
         $defaults = [
-            'reporters'      => null,
-            'autoclear'      => [],
-            'ff'             => 0
+            'reporters' => null,
+            'autoclear' => [],
+            'ff' => 0,
         ];
         $options += $defaults;
 
@@ -402,16 +431,16 @@ class Suite extends Scope
             throw new Exception('Method not allowed in this context.');
         }
 
-        $this->_locked    = true;
+        $this->_locked = true;
         $this->_reporters = $options['reporters'];
-        $this->_autoclear = (array) $options['autoclear'];
-        $this->_ff        = $options['ff'];
+        $this->_autoclear = (array)$options['autoclear'];
+        $this->_ff = $options['ff'];
 
         $this->emitReport('start', ['total' => $this->enabled()]);
         $this->process();
         $this->emitReport('end', [
-            'specs'   => $this->_results,
-            'focuses' => $this->_focuses
+            'specs' => $this->_results,
+            'focuses' => $this->_focuses,
         ]);
 
         $this->_locked = false;
@@ -429,6 +458,7 @@ class Suite extends Scope
         if (empty($this->_results['failed']) && empty($this->_results['exceptions']) && empty($this->_results['incomplete'])) {
             return true;
         }
+
         return false;
     }
 
@@ -442,6 +472,7 @@ class Suite extends Scope
         if ($this->_stats === null) {
             $this->stats();
         }
+
         return $this->_stats['focused'] + $this->_stats['normal'];
     }
 
@@ -455,6 +486,7 @@ class Suite extends Scope
         if ($this->_stats === null) {
             $this->stats();
         }
+
         return $this->focused() ? $this->_stats['focused'] : $this->_stats['normal'];
     }
 
@@ -464,8 +496,8 @@ class Suite extends Scope
     public function stop()
     {
         $this->emitReport('stop', [
-            'specs'   => $this->_results,
-            'focuses' => $this->_focuses
+            'specs' => $this->_results,
+            'focuses' => $this->_focuses,
         ]);
     }
 
@@ -477,13 +509,13 @@ class Suite extends Scope
     protected function stats()
     {
         static::$_instances[] = $this;
-        if($closure = $this->_closure) {
+        if ($closure = $this->_closure) {
             $closure($this);
         }
 
         $normal = 0;
         $focused = 0;
-        foreach($this->childs() as $child) {
+        foreach ($this->childs() as $child) {
             if ($child instanceof Suite) {
                 $result = $child->stats();
                 if ($child->focused() && !$result['focused']) {
@@ -498,6 +530,7 @@ class Suite extends Scope
             }
         }
         array_pop(static::$_instances);
+
         return $this->_stats = compact('normal', 'focused');
     }
 
@@ -505,6 +538,7 @@ class Suite extends Scope
      * Gets exit status code according passed results.
      *
      * @param  integer $status If set force a specific status to be retruned.
+     *
      * @return boolean         Returns `0` if no error occurred, `-1` otherwise.
      */
     public function status($status = null)
@@ -520,6 +554,7 @@ class Suite extends Scope
         if ($this->focused()) {
             return -1;
         }
+
         return $this->passed() ? 0 : -1;
     }
 
@@ -537,6 +572,7 @@ class Suite extends Scope
      * Gets callbacks.
      *
      * @param  string $type The type of callbacks to get.
+     *
      * @return array        The array callbacks instances.
      */
     public function callbacks($type)
@@ -587,6 +623,7 @@ class Suite extends Scope
      * Generates a hash from an instance or a string.
      *
      * @param  mixed $reference An instance or a fully namespaced class name.
+     *
      * @return string           A string hash.
      * @throws InvalidArgumentException
      */
@@ -604,7 +641,7 @@ class Suite extends Scope
     /**
      * Registers a hash. [Mainly used for optimization]
      *
-     * @param  mixed  $hash A hash to register.
+     * @param  mixed $hash A hash to register.
      */
     public static function register($hash)
     {
@@ -614,13 +651,16 @@ class Suite extends Scope
     /**
      * Gets registered hashes. [Mainly used for optimizations]
      *
-     * @param  string  $hash The hash to look up. If `null` return all registered hashes.
+     * @param  string $hash The hash to look up. If `null` return all registered hashes.
+     *
+     * @return array|bool
      */
     public static function registered($hash = null)
     {
-        if(!$hash) {
+        if (!$hash) {
             return static::$_registered;
         }
+
         return isset(static::$_registered[$hash]);
     }
 


### PR DESCRIPTION
The update intended to simplify Kahlan usage in IDEs that rely on DocBlock annotations (e.g. `@return` etc.)
No functional changes have been made.