### PR TITLE
Allow passing 'string' as Stub's implements option

### DIFF
--- a/spec/Suite/Plugin/StubSpec.php
+++ b/spec/Suite/Plugin/StubSpec.php
@@ -832,7 +832,7 @@ EOD;
 
             $result = Stub::generate([
                 'class'        => 'Kahlan\Spec\Plugin\Stub\Stub',
-                'implements'   => ['Countable'],
+                'implements'   => 'Countable',
                 'magicMethods' => false
             ]);
 

--- a/src/Plugin/Stub.php
+++ b/src/Plugin/Stub.php
@@ -256,6 +256,8 @@ class Stub
         ];
         $options += $defaults;
 
+        $options['implements'] = (array) $options['implements'];
+
         if ($options['extends']) {
             $options += ['magicMethods' => false];
         } else {
@@ -372,7 +374,7 @@ EOT;
             return '';
         }
         $classes = [];
-        foreach ((array) $implements as $implement) {
+        foreach ($implements as $implement) {
             $classes[] = '\\' . ltrim($implement, '\\');
         }
         return ' implements ' . join(', ', $classes);


### PR DESCRIPTION
It's likely to create a stub that implements just one interface, so it's more convenient (for me it's automatic as a matter of fact) to pass single string to the `implements` option:

```
Stub::create(['implements' => 'SomeInterface']);
// rather than
Stub::create(['implements' => ['SomeInterface'] ]);
```

However this will cause an error, because `_generateInterfaceMethods` requires `array` explicitly.

This PR makes sure `implements` is cast to array before passing to the appropriate methods.